### PR TITLE
Setup build and update dropwizard

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,119 +1,131 @@
 buildscript {
-  repositories {
-    maven { url 'http://repo.springsource.org/plugins-release' }
-  }
-  dependencies {
-    classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
-    classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:0.6"
-  }
+    repositories {
+        maven { url 'http://repo.springsource.org/plugins-release' }
+    }
+    dependencies {
+        classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:0.6"
+    }
 }
 
 defaultTasks 'build'
 
 subprojects {
 
-  plugins.with {
-    apply 'java'
-    apply 'maven-publish'
-    apply 'checkstyle'
-    apply 'findbugs'
-    apply 'jacoco'
+    plugins.with {
+        apply 'java'
+        apply 'maven-publish'
+        apply 'checkstyle'
+        apply 'findbugs'
+        apply 'jacoco'
 
-    apply 'propdeps'
-    apply 'propdeps-maven'
-    apply 'propdeps-idea'
-    apply 'propdeps-eclipse'
-    apply 'com.jfrog.bintray'
-  }
-
-  group = 'com.readytalk'
-  description = 'Metrics StatsD Support'
-
-  repositories {
-    mavenCentral()
-  }
-
-  dependencies {
-    compile (
-      'org.slf4j:slf4j-api:1.7.5',
-    )
-
-    optional (
-      'com.google.code.findbugs:jsr305:2.0.1',
-      'com.google.code.findbugs:annotations:2.0.1',
-    )
-
-    testCompile (
-      'junit:junit:4.11',
-      'org.mockito:mockito-all:1.9.5',
-      'org.slf4j:slf4j-jdk14:1.7.5',
-      'org.easytesting:fest-assert-core:2.0M10',
-    )
-  }
-
-  sourceCompatibility = 1.7
-  targetCompatibility = 1.7
-
-  tasks.withType(JavaCompile) {
-    options.compilerArgs << "-Xlint:all"
-  }
-
-  task sourceJar(type: Jar) {
-    from sourceSets.main.allJava
-  }
-
-  checkstyle {
-    toolVersion = '5.6'
-    showViolations = false
-    sourceSets = [sourceSets.main]
-    configFile = file("$rootDir/config/checkstyle/checkstyle.xml")
-  }
-
-  findbugs {
-    toolVersion = System.getProperty('java.version').startsWith('1.6') ? '2.0.1' : '3.0.1'
-    sourceSets = [sourceSets.main]
-    ignoreFailures = true
-  }
-
-  jacocoTestReport {
-    reports {
-      html.enabled = true
-      csv.enabled = true
-      xml.enabled = true
+        apply 'propdeps'
+        apply 'propdeps-maven'
+        apply 'propdeps-idea'
+        apply 'propdeps-eclipse'
+        apply 'com.jfrog.bintray'
     }
-  }
 
-  publishing {
-    publications {
-      mavenJava(MavenPublication) {
-        from components.java
+    group = 'com.readytalk'
+    description = 'Metrics StatsD Support'
 
-        artifact sourceJar {
-          classifier "sources"
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        compile(
+                'org.slf4j:slf4j-api:1.7.5',
+        )
+
+        optional(
+                'com.google.code.findbugs:jsr305:2.0.1',
+                'com.google.code.findbugs:annotations:2.0.1',
+        )
+
+        testCompile(
+                'junit:junit:4.11',
+                'org.mockito:mockito-all:1.9.5',
+                'org.slf4j:slf4j-jdk14:1.7.5',
+                'org.easytesting:fest-assert-core:2.0M10',
+        )
+    }
+
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
+
+    tasks.withType(JavaCompile) {
+        options.compilerArgs << "-Xlint:all"
+    }
+
+    task sourceJar(type: Jar) {
+        from sourceSets.main.allJava
+    }
+
+    checkstyle {
+        toolVersion = '5.6'
+        showViolations = false
+        sourceSets = [sourceSets.main]
+        configFile = file("$rootDir/config/checkstyle/checkstyle.xml")
+    }
+
+    findbugs {
+        toolVersion = System.getProperty('java.version').startsWith('1.6') ? '2.0.1' : '3.0.1'
+        sourceSets = [sourceSets.main]
+        ignoreFailures = true
+    }
+
+    jacocoTestReport {
+        reports {
+            html.enabled = true
+            csv.enabled = true
+            xml.enabled = true
         }
-      }
     }
-  }
 
-  bintray {
-    user = project.hasProperty('bintrayUser') ? bintrayUser : System.getenv('BINTRAY_USER')
-    key = project.hasProperty('bintrayKey') ? bintrayKey : System.getenv('BINTRAY_KEY')
-    configurations = ['archives']
-    pkg {
-      userOrg = 'readytalk'
-      repo = 'maven'
-      name = 'metrics-statsd'
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                version System.env['BUILD_NUMBER'] ?: '1.0.0-SNAPSHOT'
+
+                from components.java
+
+                artifact sourceJar
+            }
+        }
+
+        repositories {
+            maven {
+                credentials {
+                    username System.env['USERNAME'] ?: ''
+                    password System.env['PASSWORD'] ?: ''
+                }
+
+                name = 'ewe-nexus'
+                url = 'http://nexus.sb.karmalab.net/nexus/content/repositories/releases/'
+            }
+        }
     }
-  }
 
-  artifacts {
-    archives sourceJar
-  }
+    bintray {
+        user = project.hasProperty('bintrayUser') ? bintrayUser : System.getenv('BINTRAY_USER')
+        key = project.hasProperty('bintrayKey') ? bintrayKey : System.getenv('BINTRAY_KEY')
+        configurations = ['archives']
+        pkg {
+            userOrg = 'readytalk'
+            repo = 'maven'
+            name = 'metrics-statsd'
+        }
+    }
 
-  jacocoTestReport.dependsOn test
-  build.dependsOn javadoc, jacocoTestReport
+    artifacts {
+        archives sourceJar
+    }
+
+    jacocoTestReport.dependsOn test
+    build.dependsOn javadoc, jacocoTestReport
 }
 
 task wrapper(type: Wrapper) {
-  gradleVersion = '2.8'
+    gradleVersion = '2.8'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Nov 03 09:14:11 MST 2015
+#Thu Dec 13 12:19:26 PST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip

--- a/metrics3-statsd/build.gradle
+++ b/metrics3-statsd/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
   compile project(':metrics-statsd-common')
   provided (
-    'io.dropwizard.metrics:metrics-core:3.1.3'
+    'io.dropwizard.metrics:metrics-core:4.0.2'
   )
 }
 


### PR DESCRIPTION
This PR updates dropwizard to pick up changes that support java 9+ (https://github.com/dropwizard/metrics/pull/1236).

Additionally, it's adding logic to publish to nexus.